### PR TITLE
gemspec: Drop unused "executables" directive

### DIFF
--- a/faraday-detailed_logger.gemspec
+++ b/faraday-detailed_logger.gemspec
@@ -22,8 +22,6 @@ Gem::Specification.new do |spec|
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
 
-  spec.bindir = 'exe'
-  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
   spec.metadata['changelog_uri'] = 'https://github.com/envylabs/faraday-detailed_logger/blob/master/CHANGELOG.md'


### PR DESCRIPTION
This gem exposes 0 executables.