### PR TITLE
Patch license_finder and bundler incompatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,9 +8,11 @@ jobs:
         with:
           bundler-cache: "true"
           ruby-version: "2.7"
-      # See https://github.com/pivotal/LicenseFinder/issues/828#issuecomment-953359134
-      - name: "Display Bundler platform"
-        run: "bundle platform"
+      - name: "Forcibly set Bundler platform to patch for https://github.com/pivotal/LicenseFinder/issues/828"
+        run: |
+          bundle config --local deployment false
+          bundle lock --add-platform x86_64-linux
+          bundle config --local deployment true
       - name: "Run Tests"
         run: "bundle exec rake spec"
       - name: "Check Licenses"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,10 @@ jobs:
       - name: "Run Tests"
         run: "bundle exec rake spec"
       - name: "Check Licenses"
-        run: "bundle exec license_finder --quiet"
+        # See https://github.com/pivotal/LicenseFinder/issues/828#issuecomment-953359134
+        run: |
+          bundle lock --add-platform `bundle platform`
+          bundle exec license_finder --quiet
       - name: "Check Ruby Style"
         run: "bundle exec rubocop -c ./.rubocop.yml -fq"
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,13 +8,13 @@ jobs:
         with:
           bundler-cache: "true"
           ruby-version: "2.7"
+      # See https://github.com/pivotal/LicenseFinder/issues/828#issuecomment-953359134
+      - name: "Display Bundler platform"
+        run: "bundle platform"
       - name: "Run Tests"
         run: "bundle exec rake spec"
       - name: "Check Licenses"
-        # See https://github.com/pivotal/LicenseFinder/issues/828#issuecomment-953359134
-        run: |
-          bundle lock --add-platform `bundle platform`
-          bundle exec license_finder --quiet
+        run: "bundle exec license_finder --quiet"
       - name: "Check Ruby Style"
         run: "bundle exec rubocop -c ./.rubocop.yml -fq"
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,17 +8,18 @@ jobs:
         with:
           bundler-cache: "true"
           ruby-version: "2.7"
-      - name: "Forcibly set Bundler platform to patch for https://github.com/pivotal/LicenseFinder/issues/828"
+      - name: "Run Tests"
+        run: "bundle exec rake spec"
+      - name: "Check Ruby Style"
+        run: "bundle exec rubocop -c ./.rubocop.yml -fq"
+      - name: "Check Licenses"
         run: |
+          # Forcibly set Bundler platform to patch for https://github.com/pivotal/LicenseFinder/issues/828
           bundle config --local deployment false
           bundle lock --add-platform x86_64-linux
           bundle config --local deployment true
-      - name: "Run Tests"
-        run: "bundle exec rake spec"
-      - name: "Check Licenses"
-        run: "bundle exec license_finder --quiet"
-      - name: "Check Ruby Style"
-        run: "bundle exec rubocop -c ./.rubocop.yml -fq"
+
+          bundle exec license_finder --quiet
     strategy:
       matrix:
         gemfile:


### PR DESCRIPTION
Versions of bundler released since 2.1.4 have been largely compatible with license_finder. This uses @benjessop12's suggestion/finding to [hopefully temporarily] patch the problem until it can be resolved.

See https://github.com/pivotal/LicenseFinder/issues/828#issuecomment-953359134 for details.